### PR TITLE
cmd: reorganize code a bit

### DIFF
--- a/cmd/bsky-webhook/main.go
+++ b/cmd/bsky-webhook/main.go
@@ -51,8 +51,11 @@ var jetstreams = []string{
 var zstdDecoder *zstd.Decoder
 
 func init() {
+	// TODO(creachadair): For some reason the blobs reported by jetstream do not
+	// work without an explicit dictionary set, even though that isn't supposed
+	// to be necessary.
 	var err error
-	zstdDecoder, err = zstd.NewReader(nil)
+	zstdDecoder, err = zstd.NewReader(nil, zstd.WithDecoderDicts(nil))
 	if err != nil {
 		log.Panicf("failed to create zstd decoder: %v", err)
 	}

--- a/cmd/bsky-webhook/main.go
+++ b/cmd/bsky-webhook/main.go
@@ -32,7 +32,7 @@ var (
 	webhookURL = flag.String("slack-webhook-url", envOr("SLACK_WEBHOOK_URL", ""),
 		"slack webhook URL (required)")
 	bskyServerURL = flag.String("bsky-server-url", envOr("BSKY_SERVER_URL",
-		"https://bsky.network"), "bluesky pds server URL (required)")
+		"https://bsky.network"), "bluesky PDS server URL")
 	watchWord = flag.String("watch-word", envOr("WATCH_WORD", "tailscale"),
 		"the word to watch out for. may be multiple words in future (required)")
 )

--- a/cmd/bsky-webhook/main.go
+++ b/cmd/bsky-webhook/main.go
@@ -1,5 +1,5 @@
-// Program bsky-webhook receives webhooks from Bluesky and routes mentions of
-// the designated keyword(s) to a Slack channel.
+// Program bsky-webhook receives posts from Bluesky and routes mentions of the
+// designated keyword(s) to a Slack webhook.
 package main
 
 import (

--- a/cmd/bsky-webhook/types.go
+++ b/cmd/bsky-webhook/types.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type BskyMessage struct {
+	Did    string      `json:"did"`
+	Commit *BskyCommit `json:"commit"`
+	Kind   string      `json:"kind"`
+}
+
+func (m *BskyMessage) toURL(handle *string) string {
+	author := handle
+	if author == nil {
+		author = &m.Did
+	}
+
+	return fmt.Sprintf("https://bsky.app/profile/%s/post/%s", url.PathEscape(*author), url.PathEscape(m.Commit.Rkey))
+}
+
+type BskyCommit struct {
+	Rev       string      `json:"rev"`
+	Rkey      string      `json:"rkey"`
+	Record    *BskyRecord `json:"record"`
+	Operation string      `json:"operation"`
+}
+
+type BskyRecord struct {
+	Text  string    `json:"text"`
+	Embed BskyEmbed `json:"embed"`
+}
+
+type BskyEmbed struct {
+	Images []BskyImage `json:"images"`
+}
+
+type BskyImage struct {
+	Image BskyInnerImage `json:"image"`
+}
+
+type BskyInnerImage struct {
+	Ref BskyImageRef `json:"ref"`
+}
+
+type BskyImageRef struct {
+	Link string `json:"$link"`
+}
+
+type SlackAttachment struct {
+	AuthorName string `json:"author_name"`
+	AuthorIcon string `json:"author_icon"`
+	AuthorLink string `json:"author_link"`
+	Text       string `json:"text"`
+	ImageUrl   string `json:"image_url"`
+	Footer     string `json:"footer"`
+}
+
+type SlackBody struct {
+	Text        string            `json:"text"`
+	UnfurlLinks bool              `json:"unfurl_links"`
+	UnfurlMedia bool              `json:"unfurl_media"`
+	Attachments []SlackAttachment `json:"attachments"`
+}


### PR DESCRIPTION
As preparation to add secrets management and optional tailscale support,
reorganize the code a bit. Specifically:

- Add some doc comments where apropos.
- Group the flag variables (cosmetic, for legibility).
- Add additional checks for required flag/env settings.
- Move helper functions below main.
- Clean up a few variable names per https://go.dev/wiki/CodeReviewComments#initialisms
- Move the JSON type wrappers to a separate file.
- Remove an unnecessary signal handler (the default already does this).
- Pull out the round-robin address mapping into a function.
- Move the stateless compressor to the top level.
