### PR TITLE
cmd/bsky-webhook: make dial and login errors non-fatal

### DIFF
--- a/cmd/bsky-webhook/main.go
+++ b/cmd/bsky-webhook/main.go
@@ -187,13 +187,13 @@ func websocketConnection(ctx context.Context, wsUrl url.URL) error {
 
 	bsky, err := bluesky.DialWithClient(ctx, *bskyServerURL, httpClient)
 	if err != nil {
-		log.Fatal("dial bsky: ", err)
+		return fmt.Errorf("dial bsky: %w", err)
 	}
 	defer bsky.Close()
 
 	err = bsky.Login(ctx, *bskyHandle, *bskyAppKey)
 	if err != nil {
-		log.Fatal("login bsky: ", err)
+		return fmt.Errorf("login bsky: %w", err)
 	}
 
 	for ctx.Err() == nil {


### PR DESCRIPTION
Rather than fail the program when a dial or login to Bluesky fails, report the
error back to the server loop and let it retry. We might want to eventually
give up if it fails for "long enough", but for now this will help work around
transient service errors, downtime, etc.
