### PR TITLE
cmd/bsky-webhook: don't log opaque bytes on error

### DIFF
--- a/cmd/bsky-webhook/main.go
+++ b/cmd/bsky-webhook/main.go
@@ -207,7 +207,8 @@ func websocketConnection(ctx context.Context, wsUrl url.URL) error {
 
 		err = readJetstreamMessage(ctx, jetstreamMessage, bsky)
 		if err != nil {
-			log.Println("error reading jetstream message: ", jetstreamMessage, err)
+			msg := jetstreamMessage[:min(32, len(jetstreamMessage))]
+			log.Printf("error reading jetstream message %q: %v", msg, err)
 			continue
 		}
 	}


### PR DESCRIPTION
An error in a Jetstream message currently logs the raw message as bytes, which
the slog output renders as [01 02 03 ...] format. This is noisy, and also hard
to debug, so let's truncate them and quote them for the logger.
