### PR TITLE
cmd/bsky-webhook: use DID for users with invalid handles

### DIFF
--- a/cmd/bsky-webhook/main.go
+++ b/cmd/bsky-webhook/main.go
@@ -284,6 +284,11 @@ func getBskyProfile(ctx context.Context, bskyMessage BskyMessage, bsky *bluesky.
 		profile.AvatarURL = "https://up.erisa.uk/blueskydefaultavatar.png"
 	}
 
+	// if the user has an invalid (unverified) handle, links with handles will break
+	if profile.Handle == "handle.invalid" {
+		profile.Handle = profile.DID
+	}
+
 	return profile, nil
 }
 


### PR DESCRIPTION
handle.invalid breaks links